### PR TITLE
fix: dot files on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 ![size](https://img.shields.io/github/repo-size/yinyanfr/bili-pc-mp4?style=flat-square)
 [![GitHub release](https://img.shields.io/github/release/yinyanfr/bili-pc-mp4.svg?style=flat-square)](https://github.com/yinyanfr/bili-pc-mp4/releases/latest)
 
+中文文档 | [English Document](./docs/README.en.md)
+
 ```bash
 npx bili-pc-mp4 ~/Movies/bilibili
 ```
-
-中文文档 | [English Document](./docs/README.en.md)
 
 `bili-pc-mp4` 是用于将「Bilibili 桌面客户端」(Windows（非 UMP）, Mac 版)下载的视频转换为 MP4 格式的工具。
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -7,11 +7,15 @@
 
 [中文文档](../README.md) | English Document
 
+```bash
+npx bili-pc-mp4 ~/Movies/bilibili
+```
+
 `bili-pc-mp4` is a tool for converting videos downloaded from the "Bilibili Desktop Client" (Windows (non-UMP), Mac version) into MP4 format.
 
 Please note that `bili-pc-mp4` is not a downloader, and you need to first use the "Bilibili Desktop Client" to perform "offline caching" of the videos.
 
-`bili-pc-mp4 only` supports videos downloaded using the "Bilibili Desktop Client" and does not support other platform clients.
+`bili-pc-mp4` only supports videos downloaded using the "Bilibili Desktop Client" and does not support other platform clients.
 
 You need to first [install ffmpeg](./ffmpeg.en.md).
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -29,7 +29,9 @@ async function analyseTask(taskPath: string): Promise<Task> {
   }
   const id = basename(taskPath);
   const ls = await readdir(taskPath);
-  const videoFiles = ls.filter(e => e.match(/\.m4s$/));
+  const videoFiles = ls
+    .filter(e => e.match(/\.m4s$/))
+    .filter(e => !e.match(/^\./));
   const danmuFiles = ls.filter(e => e.match(/^dm[0-9]+/));
   try {
     const videoInfoReader = await readFile(join(taskPath, '.videoInfo'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export { listVideos, processFolder } from './core';


### PR DESCRIPTION
This patch fixes a bug that causes `bili-pc-mp4` to pick up trash files generated by the mac os.